### PR TITLE
Improve hueristics for x-position portraits

### DIFF
--- a/Engine/ac/character.cpp
+++ b/Engine/ac/character.cpp
@@ -2390,17 +2390,21 @@ void _displayspeech(char*texx, int aschar, int xx, int yy, int widd, int isThoug
                 if (game.options[OPT_PORTRAITSIDE] == PORTRAIT_XPOSITION) {
                     // Portrait side based on character X-positions
                     if (play.swap_portrait_lastchar < 0) {
-                        // no previous character been spoken to
-                        // therefore, find another character in this room
-                        // that it could be
-                        for (int ce = 0; ce < game.numcharacters; ce++) {
-                            if ((game.chars[ce].room == speakingChar->room) &&
-                                (game.chars[ce].on == 1) &&
-                                (ce != aschar)) {
-                                    play.swap_portrait_lastchar = ce;
-                                    break;
+                        // No previous character been spoken to
+                        // therefore, assume it's the player
+                        if(game.playercharacter != aschar && game.chars[game.playercharacter].room == speakingChar->room && game.chars[game.playercharacter].on == 1)
+                            play.swap_portrait_lastchar = game.playercharacter;
+                        else
+                            // The player's not here. Find another character in this room
+                            // that it could be
+                            for (int ce = 0; ce < game.numcharacters; ce++) {
+                                if ((game.chars[ce].room == speakingChar->room) &&
+                                    (game.chars[ce].on == 1) &&
+                                    (ce != aschar)) {
+                                        play.swap_portrait_lastchar = ce;
+                                        break;
+                                }
                             }
-                        }
                     }
 
                     if (play.swap_portrait_lastchar >= 0) {
@@ -2412,9 +2416,18 @@ void _displayspeech(char*texx, int aschar, int xx, int yy, int widd, int isThoug
                             play.swap_portrait_side = 0;
                     }
                 }
-
+                play.swap_portrait_lastlastchar = play.swap_portrait_lastchar;
                 play.swap_portrait_lastchar = aschar;
             }
+            else
+                // If the portrait side is based on the character's X position and the same character is
+                // speaking, compare against the previous *previous* character to see where the speech should be
+                if (game.options[OPT_PORTRAITSIDE] == PORTRAIT_XPOSITION && play.swap_portrait_lastlastchar >= 0) {
+                    if (speakingChar->x > game.chars[play.swap_portrait_lastlastchar].x)
+                        play.swap_portrait_side = -1;
+                    else
+                        play.swap_portrait_side = 0;
+                }
 
             // Determine whether to display the portrait on the left or right
             int portrait_on_right = 0;

--- a/Engine/ac/gamestate.h
+++ b/Engine/ac/gamestate.h
@@ -134,6 +134,7 @@ struct GameState {
     int   normal_font, speech_font;
     char  key_skip_wait;
     int   swap_portrait_lastchar;
+    int   swap_portrait_lastlastchar;
     int   seperate_music_lib;
     int   in_conversation;
     int   screen_tint;

--- a/Engine/ac/room.cpp
+++ b/Engine/ac/room.cpp
@@ -302,6 +302,7 @@ void unload_old_room() {
     }
 
     play.swap_portrait_lastchar = -1;
+    play.swap_portrait_lastlastchar = -1;
 
     for (ff = 0; ff < croom->numobj; ff++) {
         // un-export the object's script object

--- a/Engine/main/engine.cpp
+++ b/Engine/main/engine.cpp
@@ -1117,6 +1117,7 @@ void init_game_settings() {
     play.bad_parsed_word[0] = 0;
     play.swap_portrait_side = 0;
     play.swap_portrait_lastchar = -1;
+    play.swap_portrait_lastlastchar = -1;
     play.in_conversation = 0;
     play.skip_display = 3;
     play.no_multiloop_repeat = 0;


### PR DESCRIPTION
AGS often makes some wrong guess about where the portrait of a character
should be if you choose BasedOnCharacterPosition for Sierra-style
portrait positioning. I made a post about it here:

http://www.adventuregamestudio.co.uk/forums/index.php?topic=49927.0

Basically, when a character is the last character to have spoken, if
nobody else talks in the meantime, it can travel anywhere on the screen
and its portrait position will still be the same. I also found it
strange that some general assumptions (i.e. the first character to speak
could be assumed to be addressing the player instead of a random
character) were not made.
