### PR TITLE
340 fix create from screenst

### DIFF
--- a/Engine/ac/dynamicsprite.cpp
+++ b/Engine/ac/dynamicsprite.cpp
@@ -348,6 +348,8 @@ ScriptDynamicSprite* DynamicSprite_CreateFromScreenShot(int width, int height) {
             RectWH(0, 0, width, height));
     }
 
+    // Set the alpha channel to 0xFF
+    BitmapHelper::CopyTransparency(newPic, newPic, false, false);
     // replace the bitmap in the sprite set
     add_dynamic_sprite(gotSlot, gfxDriver->ConvertBitmapToSupportedColourDepth(newPic));
     ScriptDynamicSprite *new_spr = new ScriptDynamicSprite(gotSlot);


### PR DESCRIPTION
The bitmap returned by CreateFromScreenShot has no alpha in both DX5 and
DX9 mode. This causes a regression when the dynamic sprite is alpha
blended onto a GUI background or control.
