### PR TITLE
Scripting: Remove 10,000 symbol limit

### DIFF
--- a/Compiler/script/cc_symboltable.cpp
+++ b/Compiler/script/cc_symboltable.cpp
@@ -46,7 +46,23 @@ int symbolTable::get_propset(int symb) {
 
 void symbolTable::reset() {
     int rr;
-    for (rr=0;rr<numsymbols;rr++) free(sname[rr]);
+    for (rr=0;rr<numsymbols;rr++) {
+        free(sname[rr]);
+        free(funcparamtypes[rr]);
+        free(funcParamDefaultValues[rr]);
+    }
+    sname.resize(0);
+    stype.resize(0);
+    flags.resize(0);
+    vartype.resize(0);
+    soffs.resize(0);
+    ssize.resize(0);
+    sscope.resize(0);
+    arrsize.resize(0);
+    extends.resize(0);
+    funcparamtypes.resize(0);
+    funcParamDefaultValues.resize(0);
+
     numsymbols=0;
     currentscope=0;
     stringStructSym = 0;
@@ -189,21 +205,24 @@ int symbolTable::add(char*nta) {
 }
 int symbolTable::add_ex(char*nta,int typo,char sizee) {
     if (find(nta) >= 0) return -1;
-    if (numsymbols >= MAXSYMBOLS) return -1;
-    sname[numsymbols]=(char*)malloc(strlen(nta) * 2 + 5);
+    char *fullname = (char*)malloc(sizeof(char) * (strlen(nta) * 2 + 5));
     // put the name, followed by the pointer-equivalent
-    strcpy(sname[numsymbols], nta);
-    strcpy(&sname[numsymbols][strlen(nta) + 1], nta);
-    strcat(&sname[numsymbols][strlen(nta) + 1], "*");
+    strcpy(fullname, nta);
+    strcpy(&fullname[strlen(nta) + 1], nta);
+    strcat(&fullname[strlen(nta) + 1], "*");
+    sname.push_back(fullname);
 
-    stype[numsymbols]=typo;
-    ssize[numsymbols]=sizee;
-    sscope[numsymbols] = 0;
-    arrsize[numsymbols] = 0;
-    flags[numsymbols] = 0;
-    vartype[numsymbols] = 0;
-    extends[numsymbols] = 0;
-    symbolTree.addEntry(sname[numsymbols], numsymbols);
+    stype.push_back(typo);
+    flags.push_back(0);
+    vartype.push_back(0);
+    soffs.push_back(0);
+    ssize.push_back(sizee);
+    sscope.push_back(0);
+    arrsize.push_back(0);
+    extends.push_back(0);
+    funcparamtypes.push_back((unsigned long *) malloc(sizeof(long) * (MAX_FUNCTION_PARAMETERS + 1)));
+    funcParamDefaultValues.push_back((short *) malloc(sizeof(short) * (MAX_FUNCTION_PARAMETERS + 1)));
+    symbolTree.addEntry(fullname, numsymbols);
     numsymbols++;
     return numsymbols-1;
 }

--- a/Compiler/script/cc_symboltable.h
+++ b/Compiler/script/cc_symboltable.h
@@ -3,6 +3,7 @@
 
 #include "cs_parser_common.h"   // macro definitions
 #include "script/cc_treemap.h"
+#include <vector>
 
 struct symbolTable {
     int numsymbols;
@@ -13,18 +14,18 @@ struct symbolTable {
     int normalVoidSym;
     int nullSym;
     int stringStructSym;
-    char* sname[MAXSYMBOLS];
-    short stype[MAXSYMBOLS];
-    long  flags[MAXSYMBOLS];
-    short vartype[MAXSYMBOLS];
-    int   soffs[MAXSYMBOLS];
-    long  ssize[MAXSYMBOLS];  // or return type size for function
-    short sscope[MAXSYMBOLS];  // or num arguments for function
-    long  arrsize[MAXSYMBOLS];
-    short extends[MAXSYMBOLS]; // inherits another class (classes) / owning class (member vars)
+    std::vector<char *> sname;
+    std::vector<short> stype;
+    std::vector<long> flags;
+    std::vector<short> vartype;
+    std::vector<int> soffs;
+    std::vector<long> ssize; // or return type size for function
+    std::vector<short> sscope; // or num arguments for function
+    std::vector<long> arrsize;
+    std::vector<short> extends; // inherits another class (classes) / owning class (member vars)
     // functions only, save types of return value and all parameters
-    unsigned long funcparamtypes[MAXSYMBOLS][MAX_FUNCTION_PARAMETERS+1]; 
-    short funcParamDefaultValues[MAXSYMBOLS][MAX_FUNCTION_PARAMETERS+1]; 
+    std::vector<unsigned long *> funcparamtypes;
+    std::vector<short *> funcParamDefaultValues;
     char tempBuffer[2][MAX_SYM_LEN];
     int  usingTempBuffer;
 

--- a/Compiler/script/cs_parser_common.h
+++ b/Compiler/script/cs_parser_common.h
@@ -14,7 +14,6 @@
 #define NEST_DO         8 // Do statement (to be followed by a while)
 #define NEST_DOSINGLE   9 // Single Do statement
 #define MAX_FUNCTIONS 2000
-#define MAXSYMBOLS 10000
 #define MAX_FUNCTION_PARAMETERS 15
 // This is the maximum length of a "static string" in the script
 #define MAX_SYM_LEN 500


### PR DESCRIPTION
This replaces all of the fixed-size arrays in the symbol table with
vectors, eliminating the 10,000 symbol limit.
