### PR TITLE
Scripting: Permit static method calls as array indices

### DIFF
--- a/Compiler/script/cs_parser.cpp
+++ b/Compiler/script/cs_parser.cpp
@@ -1256,7 +1256,8 @@ long extract_variable_name(int fsym, ccInternalList*targ,long*slist, int *funcAt
       // save this member for use in a sub-member
     }
     else if (nexttype == SYM_OPENBRACKET) {
-      if (sym.get_type(slist[sslen]) >= NOTEXPRESSION) {
+      if ((sym.get_type(slist[sslen]) >= NOTEXPRESSION) &&
+          ((sym.get_type(slist[sslen]) != SYM_VARTYPE) || ((sym.flags[slist[sslen]] & SFLG_STRUCTTYPE) == 0))) {
         cc_error("parse error after '['");
         return -1;
         }
@@ -1269,10 +1270,14 @@ long extract_variable_name(int fsym, ccInternalList*targ,long*slist, int *funcAt
         return -1;
         }
       int braclevel = 0, linenumWas = currentline;
-      // extract the contents of the brackets - comma is allowed
-      // because you can have like  array[func(a,b)] 
+      // extract the contents of the brackets
+      // comma is allowed because you can have like array[func(a,b)] 
+      // vartype is allowed to permit access to static members, e.g. array[Game.GetColorFromRGB(0, 0, 0)]
       while ((sym.get_type(slist[sslen]) < NOTEXPRESSION) ||
-             (sym.get_type(slist[sslen]) == SYM_COMMA)) {
+             (sym.get_type(slist[sslen]) == SYM_COMMA) ||
+             (sym.get_type(slist[sslen]) == SYM_VARTYPE) && (sym.flags[slist[sslen]] & SFLG_STRUCTTYPE)) {
+        if (sym.get_type(slist[sslen - 1]) == SYM_VARTYPE && sym.get_type(slist[sslen]) != SYM_DOT)
+          break;
         if (targ->getnext() == SCODE_INVALID) {
           currentline = linenumWas;
           cc_error("missing ']'");


### PR DESCRIPTION
The previous validation for expressions within an array was a little too
strict. This adds another exception (in addition to commas) for struct
types. Also added a break if the struct isn't followed by a dot. As type
conversion won't throw an error, this ensures we don't get a static
non-property access error.
