### PR TITLE
Editor: Fixed index out of range exception

### DIFF
--- a/Editor/AGS.CScript.Compiler/Entities/FastString.cs
+++ b/Editor/AGS.CScript.Compiler/Entities/FastString.cs
@@ -64,6 +64,11 @@ namespace AGS.CScript.Compiler
             return _data.IndexOf(text, _offset) - _offset;
         }
 
+        public int IndexOf(char text, int offset)
+        {
+            return _data.IndexOf(text, _offset + offset) - _offset;
+        }
+
         public FastString Substring(int offset)
         {
             return new FastString(_data, _offset + offset);

--- a/Editor/AGS.Editor/AutoComplete.cs
+++ b/Editor/AGS.Editor/AutoComplete.cs
@@ -80,26 +80,33 @@ namespace AGS.Editor
 
         private static bool IncrementIndexToSkipAnyComments(FastString script, ref int index)
         {
-            if (index < script.Length - 1)
+            while (index < script.Length - 1 && (script[index] == '/'))
             {
-                if ((script[index] == '/') && (script[index + 1] == '/'))
+                if ((script[index + 1] == '/'))
                 {
-                    while ((script[index] != '\r') && (index < script.Length - 1))
-                    {
-                        index++;
-                    }
-                }
-                if ((script[index] == '/') && (script[index + 1] == '*'))
-                {
-                    index = script.IndexOf("*/", index + 2);
+                    index = script.IndexOf('\r', index + 2);
                     if (index < 0)
                     {
-                        index = script.Length - 1;
-                        return true;
+                        index = script.Length;
+                    }
+                }
+                else
+                {
+                    if ((script[index + 1] == '*'))
+                    {
+                        index = script.IndexOf("*/", index + 2);
+                        if (index < 0)
+                        {
+                            index = script.Length;
+                        }
+                    }
+                    else
+                    {
+                        break;
                     }
                 }
             }
-            return false;
+            return index == script.Length;
         }
 
         private static void SkipUntilMatchingClosingBrace(ref FastString script)


### PR DESCRIPTION
This fixes a bug in auto-complete, the simplest test case for which is a
new script file with:

```
{
//
```

Insert a new line _before_ the { and start typing int. The editor will
encounter an index out of range exception. The
IncrementIndexToSkipAnyComments function checked for a multiline comment
immediately after a single line comment, but did not ensure that the
index was within the bounds of the script. It also only advanced past
one comment at a time (or maybe two if you had a multiline following a
single line). I rewrote the function to do what I thought it should do:
advance past all comments in succession and return true if the end of
the script was reached.
